### PR TITLE
refactor: rename outline button selector

### DIFF
--- a/daniel-aesthetic.css
+++ b/daniel-aesthetic.css
@@ -191,7 +191,7 @@ p, ul, ol { font-size: var(--size-400); color: var(--text); }
 .btn:active { transform: translateY(0); }
 .btn:disabled { opacity: .6; cursor: not-allowed; }
 
-.btn.outline {
+.btn-outline {
   --_bg: transparent; --_fg: var(--accent);
   background: linear-gradient(var(--surface-2), var(--surface-2)) padding-box,
               linear-gradient(90deg, var(--accent-700), var(--accent-300)) border-box;
@@ -369,4 +369,4 @@ p, ul, ol { font-size: var(--size-400); color: var(--text); }
 
 /* ---------- Example component compose ---------- */
 /* <article class="card hover-raise"> ... </article> */
-/* <button class="btn">Primary</button> <button class="btn outline">Outline</button> */
+/* <button class="btn">Primary</button> <button class="btn btn-outline">Outline</button> */


### PR DESCRIPTION
## Summary
- rename `.btn.outline` selector to `.btn-outline`
- update documentation comments to reference `btn-outline`

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `node -e "const {chromium}=require('playwright');(async()=>{const browser=await chromium.launch();const page=await browser.newPage();await page.goto('file://'+process.cwd()+'/index.html');await page.waitForSelector('.btn.btn-outline');const style=await page.\$eval('.btn.btn-outline',el=>({backgroundColor:getComputedStyle(el).backgroundColor,backgroundImage:getComputedStyle(el).backgroundImage,borderWidth:getComputedStyle(el).borderTopWidth}));console.log(style);await browser.close();})();"`


------
https://chatgpt.com/codex/tasks/task_e_68acd75b46948329b940290c717156af