### PR TITLE
Add missing UI utility classes

### DIFF
--- a/daniel-aesthetic.css
+++ b/daniel-aesthetic.css
@@ -116,7 +116,8 @@ h2 { font-size: var(--size-800); }
 h3 { font-size: var(--size-700); }
 h4 { font-size: var(--size-600); }
 p, ul, ol { font-size: var(--size-400); color: var(--text); }
-.muted { color: var(--muted); }
+.muted,
+.text-muted { color: var(--muted); }
 
 .hr {
   height: 1px;
@@ -191,7 +192,8 @@ p, ul, ol { font-size: var(--size-400); color: var(--text); }
 .btn:active { transform: translateY(0); }
 .btn:disabled { opacity: .6; cursor: not-allowed; }
 
-.btn.outline {
+.btn.outline,
+.btn-outline {
   --_bg: transparent; --_fg: var(--accent);
   background: linear-gradient(var(--surface-2), var(--surface-2)) padding-box,
               linear-gradient(90deg, var(--accent-700), var(--accent-300)) border-box;
@@ -204,6 +206,11 @@ p, ul, ol { font-size: var(--size-400); color: var(--text); }
   color: var(--_fg);
   background: transparent;
   border: 1px solid var(--line);
+}
+
+.btn-sm {
+  padding: .5rem 1rem;
+  font-size: var(--size-200);
 }
 
 /* ---------- Form Elements ---------- */


### PR DESCRIPTION
## Summary
- add `.text-muted` to align with markup
- support `.btn-outline` and `.btn-sm` button variants

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acd485c450832997120d0f3f79d989